### PR TITLE
Add sonar branch name

### DIFF
--- a/buildspec/dss-sdk.yml
+++ b/buildspec/dss-sdk.yml
@@ -15,6 +15,7 @@ phases:
           ./scripts/build_all.sh kdd-samsung-remote
       - |
         sonar-scanner \
+          -Dsonar.branch.name="$([[ "$GITHUB_REF_NAME" != *"/merge" ]] && echo "$GITHUB_REF_NAME")" \
           -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oP "^refs/pull/\K[^/]+") \
           -Dsonar.pullrequest.base=${GITHUB_BASE_REF} \
           -Dsonar.pullrequest.branch=${GITHUB_HEAD_REF} \

--- a/buildspec/dss-sdk.yml
+++ b/buildspec/dss-sdk.yml
@@ -19,6 +19,8 @@ phases:
           -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oP "^refs/pull/\K[^/]+") \
           -Dsonar.pullrequest.base=${GITHUB_BASE_REF} \
           -Dsonar.pullrequest.branch=${GITHUB_HEAD_REF} \
+  post_build:
+    commands:
       - /stagemergeartifacts.sh
 
 artifacts:


### PR DESCRIPTION
Branch name is required for long-lived branch scans