### PR TITLE
Add sonar branch name (#29)

### DIFF
--- a/buildspec/dss-sdk.yml
+++ b/buildspec/dss-sdk.yml
@@ -15,9 +15,12 @@ phases:
           ./scripts/build_all.sh kdd-samsung-remote
       - |
         sonar-scanner \
+          -Dsonar.branch.name="$([[ "$GITHUB_REF_NAME" != *"/merge" ]] && echo "$GITHUB_REF_NAME")" \
           -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oP "^refs/pull/\K[^/]+") \
           -Dsonar.pullrequest.base=${GITHUB_BASE_REF} \
           -Dsonar.pullrequest.branch=${GITHUB_HEAD_REF} \
+  post_build:
+    commands:
       - /stagemergeartifacts.sh
 
 artifacts:


### PR DESCRIPTION
* Add sonar branch name

Branch name is required for long-lived branch scans

* put stagemergeartifacts script in post_build phase