### PR TITLE
Download latest sonar-scanner and build-wrapper

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,15 @@ stages:
 
 build dss-sdk:
   stage: build
-  script: build-wrapper-linux-x86-64 --out-dir bw-output/ ./scripts/build_all.sh kdd-samsung-remote
+  script:
+    # Download build wrapper from local SonarQube
+    - rm -rf /build-wrapper-linux-x86
+    - wget --no-verbose --content-disposition -E -c "$SONAR_HOST_URL/static/cpp/build-wrapper-linux-x86.zip"
+    - unzip -q build-wrapper-linux-x86.zip -d /
+    # Disable ssl verify from docker build env
+    - git config --global http.sslVerify false
+    # Build client with build-wrapper
+    - /build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output/ ./scripts/build_all.sh kdd-samsung-remote
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
   artifacts:
@@ -68,7 +76,12 @@ target unit test coverage report:
 sonar-scanner:
   stage: scan
   script:
-    - sonar-scanner -Dsonar.qualitygate.wait=true -Dsonar.cfamily.build-wrapper-output=bw-output -Dsonar.coverageReportPaths=$SONAR_UNIT_TEST_REPORT
+    # Download latest sonar-scanner from sonar-source
+    - rm -rf /sonar-scanner*
+    - wget --no-verbose --content-disposition -E -c "https://search.maven.org/remote_content?g=org.sonarsource.scanner.cli&a=sonar-scanner-cli&v=LATEST&c=linux&e=zip"
+    - unzip -q sonar-scanner-cli-*.zip -d /
+    # Scan with sonar-scanner
+    - /sonar-scanner-*-linux/bin/sonar-scanner  -Dsonar.qualitygate.wait=true -Dsonar.cfamily.build-wrapper-output=bw-output -Dsonar.coverageReportPaths=$SONAR_UNIT_TEST_REPORT
   allow_failure: true
   dependencies:
     - build dss-sdk

--- a/buildspec/dss-sdk-build.yml
+++ b/buildspec/dss-sdk-build.yml
@@ -7,10 +7,16 @@ env:
     DSSGLOBLIST: "nkv-sdk-*.tgz nkv-target-*.tgz"
 
 phases:
+  pre_build:
+    commands:
+      # Download latest build-wrapper
+      - rm -rf /build-wrapper-linux-x86
+      - wget --no-verbose --content-disposition -E -c "https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip"
+      - unzip -q build-wrapper-linux-x86.zip -d /
   build:
     commands:
       # Build dss-sdk with Sonar build-wrapper for C/C++ static analysis
-      - build-wrapper-linux-x86-64 --out-dir bw-output ./scripts/build_all.sh kdd-samsung-remote
+      - /build-wrapper-linux-x86/build-wrapper-linux-x86-64  --out-dir bw-output ./scripts/build_all.sh kdd-samsung-remote
   post_build:
     commands:
       # Copy artifacts to branch dir if this is a merge


### PR DESCRIPTION
- Delete existing sonar-scanner / build-wrapper
- Download latest sonar-scanner from sonar-source or local SonarQube (Github vs. Gitlab)
- Download latest build-wrapper from sonar-source
- use full path of sonar-scanner / build-wrapper