### PR TITLE
Only process subsystems with rdma transport

### DIFF
--- a/host/scripts/dss_host.py
+++ b/host/scripts/dss_host.py
@@ -429,9 +429,11 @@ def mountpt_to_nqn_addr_map():
         nqn = subsystems[i]["NQN"]
         for path in subsystems[i + 1]["Paths"]:
             mount_point = '/dev/' + path["Name"] + 'n1'
-            addr = re.search(r"traddr=(\S+)", path["Address"]).group(1)
-            mountpts_to_nqn_addr_map[mount_point]["nqn"] = nqn
-            mountpts_to_nqn_addr_map[mount_point]["addr"] = addr
+            transport = path["Transport"]
+            if transport == "rdma":
+                addr = re.search(r"traddr=(\S+)", path["Address"]).group(1)
+                mountpts_to_nqn_addr_map[mount_point]["nqn"] = nqn
+                mountpts_to_nqn_addr_map[mount_point]["addr"] = addr
     return mountpts_to_nqn_addr_map
 
 


### PR DESCRIPTION
When a non-rdma subsystem is encountered, dss_host.py fails silently. As a result the nkv conf json files fail to be generated. As a work-around, only process subsystems with RDMA transport.

This is the same "hack" I put in to place in the
`subnet_drive_map` function.
This `mountpt_to_nqn_addr_map` is basically an identical function, but it is called with gen2 config.
This needs to be refactored ASAP.

I see at least one other spot where this blind regex is executed (`discover_dist` function), but I don't think this is live code. Again this needs to be refactored and cleaned up.