### PR TITLE
Address deprecated SonarCloud build-wrapper-dump

### DIFF
--- a/buildspec/sonar-scanner.yml
+++ b/buildspec/sonar-scanner.yml
@@ -17,7 +17,7 @@ phases:
       # Download unit test coverage report(s)
       - aws s3 cp --recursive "$DSSS3URI/cache/dss-sdk/$GITHUB_RUN_NUMBER/unit/df_out/reports/" df_out/reports/ --only-show-errors
       # replace the old CODEBUILD_SRC_DIR with the current one in bw-output
-      - sed -i -r "s|/codebuild/output/src[^/]+/src/github.com/OpenMPDK/dss-sdk|$CODEBUILD_SRC_DIR|g" bw-output/build-wrapper-dump.json
+      - sed -i -r "s|/codebuild/output/src[^/]+/src/github.com/OpenMPDK/dss-sdk|$CODEBUILD_SRC_DIR|g" bw-output/compile_commands.json
       # Download the latest sonar-scanner
       - rm -rf /sonar-scanner*
       - wget --no-verbose --content-disposition -E -c "https://search.maven.org/remote_content?g=org.sonarsource.scanner.cli&a=sonar-scanner-cli&v=LATEST&c=linux&e=zip"
@@ -36,4 +36,5 @@ phases:
           -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oP "^refs/pull/\K[^/]+") \
           -Dsonar.pullrequest.base=$GITHUB_BASE_REF \
           -Dsonar.pullrequest.branch=$GITHUB_HEAD_REF \
-          -Dsonar.coverageReportPaths=$SONAR_UNIT_TEST_REPORT
+          -Dsonar.coverageReportPaths=$SONAR_UNIT_TEST_REPORT \
+          -Dsonar.cfamily.compile-commands=bw-output/compile_commands.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,5 @@
 sonar.organization=openmpdk
 sonar.projectKey=OpenMPDK_dss-sdk
-sonar.cfamily.build-wrapper-output=bw-output
 sonar.sources=target/,host/,utils/
 sonar.tests=target/,tests/,systemtests/
 sonar.exclusions=target/test/**/*,target/oss/**/*,host/src/**/*,**/*.java


### PR DESCRIPTION
SonarCloud has announced deprecated build-wrapper-dump.json https://docs.sonarsource.com/sonarcloud/deprecations-and-removals/

This change has not been announced for SonarQube, so we need to support build-wrapper-dump.json for SonarQube
and the new compile_commands.json for SonarCloud.

Changes made:
- removed sonar.cfamily.build-wrapper-output from sonar-project.properties file
- change sed command to replace CODEBUILD_SRC_DIR to compile_commands.json
- pass sonar.cfamily.compile-commands in sonar-scanner.yml

No change is needed for gitlab-ci because we are already passing sonar.cfamily.build-wrapper-output during sonar-scanner stage