### PR TITLE
[SPDK_TCP-NVMF/KVTRANS] Support zero byte value on target

### DIFF
--- a/target/core/kvtrans/dss_kvtrans_module.c
+++ b/target/core/kvtrans/dss_kvtrans_module.c
@@ -818,11 +818,19 @@ void dss_setup_kvtrans_req(dss_request_t *req, dss_key_t *k, dss_value_t *v)
     switch(req->opc) {
         case DSS_NVMF_KV_IO_OPC_STORE:
             kreq->req.opc = KVTRANS_OPC_STORE;
-            DSS_ASSERT(v->value);
+            if (v->length != 0) {
+                // This check is in place to support
+                // writing zero byte keys
+                DSS_ASSERT(v->value);
+            }
             break;
         case DSS_NVMF_KV_IO_OPC_RETRIEVE:
             kreq->req.opc = KVTRANS_OPC_RETRIEVE;
-            DSS_ASSERT(v->value);
+            if (v->length != 0) {
+                // This check is in place to support
+                // reading zero byte keys
+                DSS_ASSERT(v->value);
+            }
             break;
         case DSS_NVMF_KV_IO_OPC_DELETE:
             kreq->req.opc = KVTRANS_OPC_DELETE;

--- a/target/core/kvtrans/kvtrans.h
+++ b/target/core/kvtrans/kvtrans.h
@@ -185,6 +185,7 @@ typedef struct ondisk_meta_s {
 
     //value entry
     uint64_t  value_size;   // if value_size = 0, it is just holding the blkment to serve other collision keys
+                            // NB: This logic will also be used for supporting zero byte values.
     enum value_loc_e value_location;   // 0 = Along with Meta, 1 = next adjacent blkment, 2 = remote, 3 = some adjacent and  some remote
     uint8_t    num_valid_place_value_entry;
     value_loc_t   place_value [MAX_VALUE_SCATTER];

--- a/target/oss/patches/spdk/0079-spdk_tcp-NVMF-Add-support-for-zero-byte-values.patch
+++ b/target/oss/patches/spdk/0079-spdk_tcp-NVMF-Add-support-for-zero-byte-values.patch
@@ -1,0 +1,40 @@
+From 0f8a7e7a9b0025e19679cf1a8baace52e0a38e35 Mon Sep 17 00:00:00 2001
+From: Ramachaitanya Kavuluru <r.kavuluru@samsung.com>
+Date: Wed, 7 Aug 2024 20:57:11 -0700
+Subject: [PATCH 79/79] [spdk_tcp/NVMF] Add support for zero byte values
+
+---
+ lib/nvmf/rdma.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/lib/nvmf/rdma.c b/lib/nvmf/rdma.c
+index 7bd2e19..9c55d2f 100644
+--- a/lib/nvmf/rdma.c
++++ b/lib/nvmf/rdma.c
+@@ -2794,8 +2794,11 @@ nvmf_rdma_request_process(struct spdk_nvmf_rdma_transport *rtransport,
+ 				break;
+ 			}
+ 
+-			if (!rdma_req->req.data) {
++            // Extending the NULL check only for cases when length is not zero
++            // This is done to supporting zero byte values
++			if ((rdma_req->req.data) == NULL && (rdma_req->req.length != 0)) {
+ 				/* No buffers available. */
++                SPDK_DEBUGLOG(SPDK_LOG_RDMA, "No buffers available since data is null\n");
+ 				rgroup->stat.pending_data_buffer++;
+ 				break;
+ 			}
+@@ -2893,7 +2896,9 @@ nvmf_rdma_request_process(struct spdk_nvmf_rdma_transport *rtransport,
+ 			}
+ 
+ 			rdma_req->state = RDMA_REQUEST_STATE_EXECUTING;
+-			if(rdma_req->req.xfer != SPDK_NVME_DATA_NONE) {
++            // Extending NULL check to occur only when length is not zero
++            // This is done to support zero byte values
++			if((rdma_req->req.xfer != SPDK_NVME_DATA_NONE) && (rdma_req->req.length != 0)) {
+ 				assert(rdma_req->req.data != NULL);
+ 			}
+ 			spdk_nvmf_request_exec(&rdma_req->req);
+-- 
+1.8.3.1
+


### PR DESCRIPTION


        Brief Changes:
        ==============
        * Included null check on data pointer only when data length is
          not zero

        Testing Done:
        =============
        * Manual testing with nvk_test_cli

